### PR TITLE
Remove ability to pass tokens

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
     - name: pypi
       uses: MDAnalysis/pypi-deployment@main
       with:
-        token: ${{ secrets.PYPI_API_TOKEN }}
         package_name: 'mda_xdrlib'
 
   runtestpypi:
@@ -50,7 +49,6 @@ jobs:
     - name: testpypi
       uses: MDAnalysis/pypi-deployment@main
       with:
-        token: ${{ secrets.TEST_PYPI_API_TOKEN }}
         test_submission: true
         tests: true
         wheels: false
@@ -70,7 +68,6 @@ jobs:
     - name: testpypi
       uses: MDAnalysis/pypi-deployment@main
       with:
-        token: ${{ secrets.TEST_PYPI_API_TOKEN_GDF }}
         test_submission: true
         tests: true
         wheels: false

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Please see [action.yaml()] for all details.
 
 The following options can be passed:
 
-1. `token` (required): The relevant PyPi or TestPyPi upload token for the package.
-2. `test_submission`: Bool, if true the package will be uploaded to TestPyPi instead of PyPi (default: false)
-3. `wheels`: Bool, if true wheels will be created and uploaded (default: true)
-4. `tests`: Bool, if true there will be an attempt to pull down the newly uploaded package and run tests. Please note this assumes testing via `pytest --pyargs inputs.package_name` (default: true)
-5. `package_name`: Name of package on PyPi, only needed if testing package post-upload. Used for pip installing (default: 'MDAnalysis')
-6. `module_name`: Name of package directory, only needed if testing package post-upload. Used for pytest pyargs. If unset will use `package_name` (default: null)
+1. `test_submission`: Bool, if true the package will be uploaded to TestPyPi instead of PyPi (default: false)
+2. `wheels`: Bool, if true wheels will be created and uploaded (default: true)
+3. `tests`: Bool, if true there will be an attempt to pull down the newly uploaded package and run tests. Please note this assumes testing via `pytest --pyargs inputs.package_name` (default: true)
+4. `package_name`: Name of package on PyPi, only needed if testing package post-upload. Used for pip installing (default: 'MDAnalysis')
+5. `module_name`: Name of package directory, only needed if testing package post-upload. Used for pytest pyargs. If unset will use `package_name` (default: null)
 
 ### Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,9 +1,6 @@
 name: pypi-deployment
 description: Package and deploy to PyPi or TestPyPi
 inputs:
-  token:
-    description: 'PyPi or TestPyPi token.'
-    required: true
   test_submission:
     description: 'True if this should be sent to TestPypi instead of PyPi.'
     default: false
@@ -60,7 +57,6 @@ runs:
       id: pypi_upload
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ inputs.token }}
         repository_url: https://test.pypi.org/legacy/
         skip-existing: true
 
@@ -68,7 +64,6 @@ runs:
       id: testpypi_upload
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ inputs.token }}
         skip-existing: true
 
     - name: run_pytest


### PR DESCRIPTION
For the sake of best practice & uniform actions across the MDAnalysis ecosystem, the ability to pass API token is being removed.

All future uses of this action will only work with OpenID connect trusted publisher workflows.